### PR TITLE
Use angular to serialize objects when building REST params

### DIFF
--- a/src/ShareCoffee.Rest.coffee
+++ b/src/ShareCoffee.Rest.coffee
@@ -48,6 +48,10 @@ root.ShareCoffee.RESTFactory = class
     options.extend angularProperties
     options.eTag = '*' if @method is 'DELETE' or (@updateQuery is on and not options.eTag?)
 
+    stringify = if (typeof root.angular isnt "undefined")
+      root.angular.toJson
+    else JSON.stringify
+
     result =
       url: options.getUrl()
       method: @method
@@ -56,7 +60,7 @@ root.ShareCoffee.RESTFactory = class
         'Content-Type': ShareCoffee.REST.applicationType
         'X-HTTP-Method' : 'MERGE'
         'If-Match' : options.eTag
-      data: if typeof options.payload is 'string' then options.payload else JSON.stringify(options.payload)
+      data: if typeof options.payload is 'string' then options.payload else stringify(options.payload)
 
     if @method is 'GET'
       delete result.headers['Content-Type']

--- a/test/ShareCoffee.Rest.tests.coffee
+++ b/test/ShareCoffee.Rest.tests.coffee
@@ -344,6 +344,14 @@ describe 'ShareCoffee.REST', ->
       actual = sut.angularJS {url: 'foo', payload: payload}
       actual.data.should.equal expected
 
+    it 'should stringify the payload using angular when available if it is not given as string', ->
+      payload =
+        name: 'foo'
+      root.angular = toJson: sinon.stub().withArgs(payload).returns("angular serialized")
+      sut = new ShareCoffee.RESTFactory 'POST'
+      actual = sut.angularJS {url: 'foo', payload: payload}
+      actual.data.should.equal "angular serialized"
+
     it 'should provide a If-Match property with value * if mathod is DELETE', ->
       sut = new ShareCoffee.RESTFactory 'DELETE'
       actual = sut.angularJS {url: 'foo'}


### PR DESCRIPTION
angular.toJson ignores all properties of an object that start with a '$', i.e. internal angular properties added to objects, when serializing it.
